### PR TITLE
:sparkles: Notionからタスクの実行履歴を取れるようにした

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -24,6 +24,7 @@
     "@emotion/react": "^11.10.4",
     "@emotion/styled": "^11.10.4",
     "@types/uuid": "^8.3.4",
+    "axios": "^1.4.0",
     "dayjs": "^1.11.7",
     "framer-motion": "^7.5.0",
     "next": "12.3.1",

--- a/app/src/components/Notion.tsx
+++ b/app/src/components/Notion.tsx
@@ -1,0 +1,81 @@
+import { useEffect, useState } from 'react'
+import { NotionDataType } from '../model/notion'
+import axios from 'axios'
+import { Flex, Spacer, Text } from '@chakra-ui/react'
+
+export const Notion = () => {
+  const [notionData, setNotionData] = useState<NotionDataType[]>([])
+  useEffect(() => {
+    const url = '/api/notion'
+    const data = {}
+    axios
+      .post(url, data)
+      .then((res) => {
+        setNotionData(res.data.data.results)
+      })
+      .catch((err) => {
+        console.error(err)
+      })
+  }, [])
+
+  return (
+    <Flex
+      w="720px"
+      h="500px"
+      justifyContent="center"
+      alignItems="center"
+      direction="column"
+    >
+      {/*  display notionData */}
+      {notionData.map((data) => {
+        return <NotionTaskContainer key={data.id} {...data} />
+      })}
+    </Flex>
+  )
+}
+
+const NotionTaskContainer = (task: NotionDataType) => {
+  const start = convertToTime(task.properties.Time.date.start)
+  const end = convertToTime(task.properties.Time.date.end)
+  const elapseTime = calcElapseTime(
+    task.properties.Time.date.start,
+    task.properties.Time.date.end
+  )
+  return (
+    <Flex w={'600px'}>
+      <Flex px={2}>
+        <Text color="white">{task.properties.Name.title[0].plain_text}</Text>
+      </Flex>
+      <Spacer />
+      <Flex px={2}>
+        <Text color="white">{start}</Text>
+      </Flex>
+      <Text color="white">~</Text>
+      <Flex px={2}>
+        <Text color="white">{end}</Text>
+      </Flex>
+      <Flex px={2}>
+        <Text color="white">{elapseTime}</Text>
+      </Flex>
+    </Flex>
+  )
+}
+
+const convertToTime = (time: string) => {
+  const date = new Date(time)
+  const hour = date.getHours().toString().padStart(2, '0')
+  const minute = date.getMinutes().toString().padStart(2, '0')
+  return `${hour}:${minute}`
+}
+
+const calcElapseTime = (start: string, end: string) => {
+  const startDate = new Date(start)
+  const endDate = new Date(end)
+  const elapseTime = endDate.getTime() - startDate.getTime()
+  const hour = Math.floor((elapseTime / (60 * 60)) % 24).toString()
+  const minute = Math.floor((elapseTime / 60) % 60)
+    .toString()
+    .padStart(2, '0')
+  const second = (elapseTime % 60).toString().padStart(2, '0')
+  return `${hour}:${minute}:${second}`
+}

--- a/app/src/components/Stopwatch.tsx
+++ b/app/src/components/Stopwatch.tsx
@@ -1,6 +1,7 @@
-import { Button, Flex, Text, Input, Spacer } from '@chakra-ui/react'
-import { StopwatchHistoryEntity, useStopwatch } from './useStopwatch'
+import { Button, Flex, Text } from '@chakra-ui/react'
+import { useStopwatch } from './useStopwatch'
 import { useState } from 'react'
+import { Tasks } from './Tasks'
 
 export const Stopwatch = () => {
   const {
@@ -37,21 +38,11 @@ export const Stopwatch = () => {
         stopStopwatch={stopStopwatch}
         isRunning={isRunning}
       />
-      <Flex my={8}>
-        <Input
-          w={displayWidth}
-          value={doingTask}
-          placeholder={"What's next?"}
-          onChange={(e) => setDoingTask(e.target.value)}
-          color={'white'}
-          borderColor="gray.500"
-          _focusVisible={{ borderColor: 'gray.300' }}
-          _hover={{ borderColor: 'gray.300' }}
-        />
-      </Flex>
-      <HistoryContainer
-        displayWidth={displayWidth}
+      <Tasks
         history={history}
+        displayWidth={displayWidth}
+        doingTask={doingTask}
+        setDoingTask={setDoingTask}
         resetStopwatch={resetStopwatch}
       />
     </Flex>
@@ -152,70 +143,4 @@ const DisplayTime = ({ hour, minute, second }: DisplayTimeProps) => {
       </Text>
     </Flex>
   )
-}
-
-type HistoryContainerProps = {
-  displayWidth: string
-  history: StopwatchHistoryEntity[]
-  resetStopwatch: () => void
-}
-
-const HistoryContainer = ({
-  displayWidth,
-  history,
-  resetStopwatch,
-}: HistoryContainerProps) => {
-  return (
-    <Flex
-      direction="column"
-      h="500px"
-      maxH="500px"
-      overflow="auto"
-      pr={4}
-      w={displayWidth}
-    >
-      <Flex justifyContent="right" w={displayWidth} mt={10} mb={4}>
-        <Button
-          variant="ghost"
-          color="white"
-          size="md"
-          borderColor="white"
-          _hover={{ bg: 'gray.700' }}
-          _active={{ bg: 'gray.600' }}
-          bg="gray.900"
-          onClick={() => resetStopwatch()}
-          display={history.length > 0 ? 'Flex' : 'none'}
-        >
-          リセット
-        </Button>
-      </Flex>
-      {history.map((h, i) => (
-        <DisplayEvent key={i} {...h} />
-      ))}
-    </Flex>
-  )
-}
-
-const DisplayEvent = (event: StopwatchHistoryEntity) => {
-  return (
-    <Flex mt={1}>
-      <Text color="white" fontSize="xl" pr={4}>
-        {event.task}
-      </Text>
-      <Spacer />
-      <Text color="white" fontSize="xl">
-        {TranslateToTime(event.start)}
-      </Text>
-      <Text color="white" fontSize="xl">
-        ~
-      </Text>
-      <Text color="white" fontSize="xl">
-        {event.end ? TranslateToTime(event.end) : ''}
-      </Text>
-    </Flex>
-  )
-}
-
-const TranslateToTime = (timestamp: number) => {
-  return new Date(timestamp * 1000).toLocaleTimeString()
 }

--- a/app/src/components/Tasks.tsx
+++ b/app/src/components/Tasks.tsx
@@ -1,0 +1,108 @@
+import { Button, Flex, Input, Spacer, Text } from '@chakra-ui/react'
+import { StopwatchHistoryEntity } from './useStopwatch'
+import { Notion } from './Notion'
+
+type TasksProps = {
+  history: StopwatchHistoryEntity[]
+  displayWidth: string
+  doingTask: string
+  setDoingTask: (task: string) => void
+  resetStopwatch: () => void
+}
+
+export const Tasks = ({
+  history,
+  displayWidth,
+  doingTask,
+  setDoingTask,
+  resetStopwatch,
+}: TasksProps) => {
+  return (
+    <>
+      <Flex my={8}>
+        <Input
+          w={displayWidth}
+          value={doingTask}
+          placeholder={"What's next?"}
+          onChange={(e) => setDoingTask(e.target.value)}
+          color={'white'}
+          borderColor="gray.500"
+          _focusVisible={{ borderColor: 'gray.300' }}
+          _hover={{ borderColor: 'gray.300' }}
+        />
+      </Flex>
+      <Notion />
+      <HistoryContainer
+        displayWidth={displayWidth}
+        history={history}
+        resetStopwatch={resetStopwatch}
+      />
+    </>
+  )
+}
+
+type HistoryContainerProps = {
+  displayWidth: string
+  history: StopwatchHistoryEntity[]
+  resetStopwatch: () => void
+}
+
+const HistoryContainer = ({
+  displayWidth,
+  history,
+  resetStopwatch,
+}: HistoryContainerProps) => {
+  return (
+    <Flex
+      direction="column"
+      h="500px"
+      maxH="500px"
+      overflow="auto"
+      pr={4}
+      w={displayWidth}
+    >
+      <Flex justifyContent="right" w={displayWidth} mt={10} mb={4}>
+        <Button
+          variant="ghost"
+          color="white"
+          size="md"
+          borderColor="white"
+          _hover={{ bg: 'gray.700' }}
+          _active={{ bg: 'gray.600' }}
+          bg="gray.900"
+          onClick={() => resetStopwatch()}
+          display={history.length > 0 ? 'Flex' : 'none'}
+        >
+          リセット
+        </Button>
+      </Flex>
+      {history.map((h, i) => (
+        <DisplayEvent key={i} {...h} />
+      ))}
+    </Flex>
+  )
+}
+
+const DisplayEvent = (event: StopwatchHistoryEntity) => {
+  return (
+    <Flex mt={1}>
+      <Text color="white" fontSize="xl" pr={4}>
+        {event.task}
+      </Text>
+      <Spacer />
+      <Text color="white" fontSize="xl">
+        {TranslateToTime(event.start)}
+      </Text>
+      <Text color="white" fontSize="xl">
+        ~
+      </Text>
+      <Text color="white" fontSize="xl">
+        {event.end ? TranslateToTime(event.end) : ''}
+      </Text>
+    </Flex>
+  )
+}
+
+const TranslateToTime = (timestamp: number) => {
+  return new Date(timestamp * 1000).toLocaleTimeString()
+}

--- a/app/src/model/notion.ts
+++ b/app/src/model/notion.ts
@@ -1,0 +1,73 @@
+type User = {
+  object: string
+  id: string
+}
+
+type PropertyTitleContent = {
+  content: string
+  link: null | string
+}
+
+type PropertyTitle = {
+  type: string
+  text: PropertyTitleContent
+  annotations: {
+    bold: boolean
+    italic: boolean
+    strikethrough: boolean
+    underline: boolean
+    code: boolean
+    color: string
+  }
+  plain_text: string
+  href: null | string
+}
+
+type PropertyDate = {
+  start: string
+  end: string
+  time_zone: null | string
+}
+
+type Properties = {
+  Tag: {
+    id: string
+    type: string
+    multi_select: Array<{ id: string; name: string; color: string }>
+  }
+  Time: {
+    id: string
+    type: string
+    date: PropertyDate
+  }
+  Name: {
+    id: string
+    type: string
+    title: PropertyTitle[]
+  }
+}
+
+type NotionDataType = {
+  object: string
+  id: string
+  created_time: string
+  last_edited_time: string
+  created_by: User
+  last_edited_by: User
+  parent: {
+    type: string
+    database_id: string
+  }
+  archived: boolean
+  properties: Properties
+  url: string
+}
+
+export type {
+  User,
+  PropertyTitleContent,
+  PropertyTitle,
+  PropertyDate,
+  Properties,
+  NotionDataType,
+}

--- a/app/src/pages/api/notion.ts
+++ b/app/src/pages/api/notion.ts
@@ -1,0 +1,27 @@
+import axios from 'axios'
+import { NextApiRequest, NextApiResponse } from 'next'
+
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  const url = `https://api.notion.com/v1/databases/${process.env.DB_ID}/query`
+  const secret = process.env.SECRET_KEY
+  const notionVersion = '2021-08-16'
+  const data = {}
+  axios
+    .post(url, data, {
+      headers: {
+        Authorization: `Bearer ${secret}`,
+        'Notion-Version': notionVersion,
+        'Content-Type': 'application/json',
+        'Allow-Control-Allow-Origin': '*',
+      },
+    })
+    .then((resp) => {
+      console.log(resp)
+      console.log(resp.data.results[0])
+      res.status(200).json({ message: 'Success', data: resp.data })
+    })
+    .catch((err) => {
+      console.error(err)
+      res.status(500).json({ message: 'Failed' })
+    })
+}

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -2099,6 +2099,15 @@ axe-core@^4.4.3:
   resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.4.3.tgz#11c74d23d5013c0fa5d183796729bc3482bd2f6f"
   integrity sha512-32+ub6kkdhhWick/UjvEwRchgoetXqTK14INLqbGm5U2TzBkBNF3nQtLYm8ovxSkQWArjEQvftCKryjZaATu3w==
 
+axios@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.4.0.tgz#38a7bf1224cd308de271146038b551d725f0be1f"
+  integrity sha512-S4XCWMEmzvo64T9GfvQDOXgYRDJ/wsSZc7Jvdgx5u1sd0JwsuPLqb3SYmusag+edF6ziyMensPVqLTSc1PiSEA==
+  dependencies:
+    follow-redirects "^1.15.0"
+    form-data "^4.0.0"
+    proxy-from-env "^1.1.0"
+
 axobject-query@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/axobject-query/-/axobject-query-2.2.0.tgz#943d47e10c0b704aa42275e20edf3722648989be"
@@ -3019,6 +3028,11 @@ focus-lock@^0.11.2:
   integrity sha512-4n0pYcPTa/uI7Q66BZna61nRT7lDhnuJ9PJr6wiDjx4uStg491ks41y7uOG+s0umaaa+hulNKSldU9aTg9/yVg==
   dependencies:
     tslib "^2.0.3"
+
+follow-redirects@^1.15.0:
+  version "1.15.2"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.2.tgz#b460864144ba63f2681096f274c4e57026da2c13"
+  integrity sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==
 
 form-data@^4.0.0:
   version "4.0.0"
@@ -4572,6 +4586,11 @@ prop-types@^15.6.2, prop-types@^15.8.1:
     loose-envify "^1.4.0"
     object-assign "^4.1.1"
     react-is "^16.13.1"
+
+proxy-from-env@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
+  integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
 
 psl@^1.1.33:
   version "1.9.0"


### PR DESCRIPTION
## やったこと
- Notionからタスクの実行履歴を取れるようにした

## やってないこと
- 誰でも使える状態にはしていない
  - 自分で適切な項目名を持つDBをNotionに作る必要あり
  - 自分でNotion APIのSecretを発行し、`.env.local`に適切な変数名で保存する必要あり
- タスクを表示する機能以外の実装

<img width="941" alt="スクリーンショット 2023-05-21 14 56 13" src="https://github.com/furiko/task-fast/assets/38683013/2757704f-dd48-4b5b-902b-5d2935682c44">
