### PR TITLE
:sparkles: 環境変数がセットされていない時にエラーになるので対応した

### DIFF
--- a/app/src/components/Error/index.tsx
+++ b/app/src/components/Error/index.tsx
@@ -1,0 +1,38 @@
+import { Flex, Text, Alert, AlertIcon } from '@chakra-ui/react'
+
+export const Error = () => {
+  return (
+    <Flex
+      h="500px"
+      maxH="500px"
+      overflow="auto"
+      w="600px"
+      alignItems="center"
+      direction="column"
+      pt={4}
+    >
+      <Alert color="white" status="error">
+        <AlertIcon />
+        Notionに接続できません。SECRET_KEYとDB_IDを設定してください。
+      </Alert>
+
+      <Flex direction="column">
+        <Text color="white" pt={10} pb={4}>
+          設定方法
+        </Text>
+        <Text color="white">1. app/.env.localを作成</Text>
+
+        <Text color="white">2. app/.env.localにSECRET_KEYとDB_IDを設定</Text>
+
+        <Text color="white" pt={10} pb={4}>
+          設定例
+        </Text>
+
+        <Flex background="gray.700" direction="column">
+          <Text color="white">SECRET_KEY=xxxxxxxxxxx</Text>
+          <Text color="white">DB_ID=xxxxxxxxxxx</Text>
+        </Flex>
+      </Flex>
+    </Flex>
+  )
+}

--- a/app/src/pages/index.tsx
+++ b/app/src/pages/index.tsx
@@ -2,6 +2,7 @@ import { Flex } from '@chakra-ui/react'
 import { NextPage } from 'next'
 import useSWR from 'swr'
 
+import { Error } from '../components/Error'
 import { TaskController } from '../components/TaskController'
 import { TaskManager } from '../components/TaskManager'
 import { Task } from '../models/task'
@@ -13,6 +14,8 @@ type GetTasksResponse = {
   message: string
 }
 
+const Failed = 'Failed'
+
 const Home: NextPage = () => {
   const { data, error, isLoading } = useSWR<GetTasksResponse>(
     '/api/tasks',
@@ -21,6 +24,24 @@ const Home: NextPage = () => {
 
   if (isLoading) return <Flex height="100vh" width="full" bg="gray.900" />
   if (error) return <Flex>{error}</Flex>
+
+  const responseMessage = data?.message
+
+  if (responseMessage === Failed) {
+    return (
+      <Flex
+        justifyContent="center"
+        alignItems="center"
+        height="100vh"
+        width="full"
+        bg="gray.900"
+        direction="column"
+      >
+        <TaskController ongoingTask={undefined} />
+        <Error />
+      </Flex>
+    )
+  }
 
   const task = data?.data.find((task: Task) => task.end === null)
 


### PR DESCRIPTION
## やったこと
Notionに接続しないと使えなくなるので、エラー文面を整備した。

## 今後のタスク
`SECRET _KEY`と`DB_ID`をセットしても、DBのカラムが適切でないと使えないので、その案内を用意する

## エラー画面のスクショ
<img width="1912" alt="スクリーンショット 2023-06-22 20 21 57" src="https://github.com/furiko/task-fast/assets/38683013/4f12c288-5935-4a80-9e4f-06588e4e5f76">
